### PR TITLE
Resource measures

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ npm start
 
 # In another shell, run grafton.
 grafton test --product=bonnets --plan=small --region=aws::us-east-1 \
-    --client-id=$CLIENT_ID \
-    --client-secret=$CLIENT_SECRET \
-    --connector-port=$CONNECTOR_PORT \
+    --client-id=21jtaatqj8y5t0kctb2ejr6jev5w8 \
+    --client-secret=3yTKSiJ6f5V5Bq-kWF0hmdrEUep3m3HKPTcPX7CdBZw \
+    --connector-port=3001 \
     --new-plan=large \
-    $CONNECTOR_URL
+    http://localhost:4567
 
 # If everything went well, you'll be greeted with plenty of green check marks!
 ```

--- a/index.js
+++ b/index.js
@@ -153,6 +153,23 @@ server.del("/v1/resources/:id", verifyMiddleware, function(req, res, next) {
   res.end();
 });
 
+// Get measures resource
+server.get("/v1/resources/:id/measures", verifyMiddleware, function(req, res, next) {
+  var resource = db.resources[req.params.id];
+  if (!resource) {
+    res.statusCode = 404;
+    return res.json({ message: "no such resource" });
+  }
+
+  res.statusCode = 200;
+  res.json({
+    resource_id: req.params.id,
+    period_start: "2018-05-01T00:00:00.000Z",
+    period_end: "2018-05-31T23:59:59.000Z",
+    measures: { "feature-a": 0, "feature-b": 1000 }
+  });
+});
+
 // Create credential
 server.put("/v1/credentials/:id", verifyMiddleware, function(req, res, next) {
   var resource = db.resources[req.body.resource_id];


### PR DESCRIPTION
* Fixes this issue: Issue #2 
* Hard-coded `period_start` and `period_end` since `params` only has `id` as compared to Ruby which has all of them.
* Update README.md to point to provider API, instead of `$CONNECTOR_URL`.