### PR TITLE
fix: return current period and provider specific features

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ grafton test --product=bonnets --plan=small --region=aws::us-east-1 \
     --client-secret=$CLIENT_SECRET \
     --connector-port=$CONNECTOR_PORT \
     --new-plan=large \
+    --resource-measures "{\"storage\": 30, \"processing-time\": 5}" \
     http://localhost:4567
 
 # If everything went well, you'll be greeted with plenty of green check marks!

--- a/index.js
+++ b/index.js
@@ -164,9 +164,9 @@ server.get("/v1/resources/:id/measures", verifyMiddleware, function(req, res, ne
   res.statusCode = 200;
   res.json({
     resource_id: req.params.id,
-    period_start: "2018-05-01T00:00:00.000Z",
-    period_end: "2018-05-31T23:59:59.000Z",
-    measures: { "feature-a": 0, "feature-b": 1000 }
+    period_start: req.query["period_start"],
+    period_end: req.query["period_end"],
+    measures: { "storage": 30, "processing-time": 5 } // 30 GB, used for 5 hours.
   });
 });
 


### PR DESCRIPTION
- [x] The periods returned should be the ones passed in.
- [x] Showing an example with custom metered features